### PR TITLE
Revamp mappings module and MappingEditor

### DIFF
--- a/config/locale.json
+++ b/config/locale.json
@@ -130,7 +130,10 @@
       "settingClearOnSaveTooltip": "When turned on, the editor will be cleared after a mapping was saved.",
       "settingOnly1to1mappings": "Only allow 1-to-1 mappings (1-to-n otherwise)",
       "settingOnly1to1mappingsTooltip": "When turned on, only 1-to-1 mappings will be allowed. When turned off, 1-to-n mappings will be allowed.",
-      "notSaved": "not saved"
+      "notSaved": "not saved",
+      "invalid": "Invalid",
+      "invalidMissing": "Missing {0}",
+      "invalidWhitelist": "{0} not allowed in this registry"
     },
     "mappingBrowser": {
       "title": "Mapping Browser",
@@ -401,7 +404,10 @@
       "settingClearOnSaveTooltip": "Falls eingeschaltet wird der Editor nach dem Speichern eines Mappings geleert.",
       "settingOnly1to1mappings": "Nur 1-zu-1 Mappings erlauben (sonst 1-zu-n)",
       "settingOnly1to1mappingsTooltip": "Falls eingeschaltet, werden nur 1-zu-1 Mappings erlaubt. Falls ausgeschaltet, werden 1-zu-n Mappings erlaubt.",
-      "notSaved": "nicht gespeichert"
+      "notSaved": "nicht gespeichert",
+      "invalid": "Ungültig",
+      "invalidMissing": "{0} fehlt",
+      "invalidWhitelist": "{0} nicht erlaubt in diesem Register"
     },
     "settingsTabs": [
       "Account",

--- a/config/locale.json
+++ b/config/locale.json
@@ -133,7 +133,7 @@
       "notSaved": "not saved",
       "invalid": "Invalid",
       "invalidMissing": "Missing {0}",
-      "invalidWhitelist": "{0} not allowed in this registry"
+      "invalidWhitelist": "{0} not allowed in {1}"
     },
     "mappingBrowser": {
       "title": "Mapping Browser",
@@ -407,7 +407,7 @@
       "notSaved": "nicht gespeichert",
       "invalid": "Ungültig",
       "invalidMissing": "{0} fehlt",
-      "invalidWhitelist": "{0} nicht erlaubt in diesem Register"
+      "invalidWhitelist": "{0} nicht erlaubt in {1}"
     },
     "settingsTabs": [
       "Account",

--- a/src/components/MappingBrowserTable.vue
+++ b/src/components/MappingBrowserTable.vue
@@ -566,18 +566,6 @@ export default {
       return this.$store.getters.getCurrentRegistry
     },
   },
-  watch: {
-    currentRegistry(registry) {
-      // If registry changes and does not match the registry of the current original mapping, remove original
-      // TODO: Is this the best way to solve this? Maybe use URIs instead?
-      if (!this.$jskos.compare(registry, _.get(this.$store.state.mapping.original, "_provider.registry"))) {
-        this.$store.commit({
-          type: "mapping/set",
-          original: null,
-        })
-      }
-    },
-  },
   created() {
     this.hover = _.debounce(this._hover, 20)
   },
@@ -586,7 +574,6 @@ export default {
   },
   methods: {
     edit(data) {
-      let canEdit = this.canEdit(data)
       let copyWithReferences = mapping => {
         let newMapping = this.$jskos.copyDeep(mapping)
         newMapping.from.memberSet = mapping.from.memberSet.slice()
@@ -606,7 +593,7 @@ export default {
       this.$store.commit({
         type: "mapping/set",
         mapping,
-        original: canEdit && mapping._provider && mapping._provider.has.canSaveMappings && this.$jskos.compare(mapping._provider.registry, this.currentRegistry) ? copyWithReferences(mapping) : null,
+        original: data.item.mapping,
       })
     },
     canEdit(data) {

--- a/src/components/MappingEditor.vue
+++ b/src/components/MappingEditor.vue
@@ -420,7 +420,6 @@ export default {
       mapping.modified = (new Date()).toISOString()
       this.loadingGlobal = true
       this.$store.dispatch({ type: "mapping/saveMapping" }).then(mapping => {
-        console.log(mapping)
         if (!mapping) {
           // TODO: Adjust
           let message = this.$t("alerts.mappingNotSaved")

--- a/src/components/MappingEditor.vue
+++ b/src/components/MappingEditor.vue
@@ -20,7 +20,7 @@
     <div
       v-if="canSaveMapping"
       class="mappingEditor-mappingAlert fontSize-small fontWeight-heavy">
-      {{ $t("mappingEditor.notSaved") }}
+      {{ $util.prefLabel($store.getters.getCurrentRegistry) }}: {{ $t("mappingEditor.notSaved") }}
     </div>
     <div
       v-if="mappingInvalidReason"
@@ -316,7 +316,7 @@ export default {
         const whitelist = _.get(this.$store.getters.getCurrentRegistry, `config.mappings.${side}Whitelist`)
         if (whitelist) {
           if (!whitelist.find(s => this.$jskos.compare(s, this.mapping[side]))) {
-            return this.$t("mappingEditor.invalidWhitelist", [`${side} ${this.$util.prefLabel(this.mapping[side], null, false) || ""}`])
+            return this.$t("mappingEditor.invalidWhitelist", [`${side} ${this.$util.prefLabel(this.mapping[side], null, false) || ""}`, this.$util.prefLabel(this.$store.getters.getCurrentRegistry)])
           }
         }
       }

--- a/src/main.js
+++ b/src/main.js
@@ -27,7 +27,7 @@ Vue.component("tab", Tab)
 
 // Add fontawesome
 import { library } from "@fortawesome/fontawesome-svg-core"
-import { faStar, faPlusCircle, faExchangeAlt, faThumbsUp, faThumbsDown, faAngleDown, faAngleRight, faAngleLeft, faLevelUpAlt, faLevelDownAlt, faEllipsisV, faEllipsisH, faSortUp, faTimesCircle, faLink, faIdCard, faUser, faSearch, faFilter, faCode, faCog, faDownload, faCaretDown, faInfoCircle, faComment, faEdit, faSave, faTrashAlt, faBan, faWindowMinimize, faPlusSquare, faCheck, faCheckSquare, faLock, faLockOpen, faExternalLinkSquareAlt, faLongArrowAltDown, faLongArrowAltUp, faExternalLinkAlt, faPuzzlePiece, faExclamation, faShareAltSquare, faRecycle, faCaretSquareLeft, faCaretSquareRight, faClipboard, faAngleDoubleRight, faClone } from "@fortawesome/free-solid-svg-icons"
+import { faStar, faPlusCircle, faExchangeAlt, faThumbsUp, faThumbsDown, faAngleDown, faAngleRight, faAngleLeft, faLevelUpAlt, faLevelDownAlt, faEllipsisV, faEllipsisH, faSortUp, faTimesCircle, faLink, faIdCard, faUser, faSearch, faFilter, faCode, faCog, faDownload, faCaretDown, faInfoCircle, faComment, faEdit, faSave, faTrashAlt, faBan, faWindowMinimize, faPlusSquare, faCheck, faCheckSquare, faLock, faLockOpen, faExternalLinkSquareAlt, faLongArrowAltDown, faLongArrowAltUp, faExternalLinkAlt, faPuzzlePiece, faExclamation, faShareAltSquare, faRecycle, faCaretSquareLeft, faCaretSquareRight, faClipboard, faAngleDoubleRight, faClone, faExclamationCircle } from "@fortawesome/free-solid-svg-icons"
 import { faGithub } from "@fortawesome/free-brands-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome"
 library.add(faStar)
@@ -79,6 +79,7 @@ library.add(faCaretSquareRight)
 library.add(faClipboard)
 library.add(faAngleDoubleRight)
 library.add(faClone)
+library.add(faExclamationCircle)
 Vue.component("font-awesome-icon", FontAwesomeIcon)
 
 // Add objects mixin

--- a/src/store/modules/mapping.js
+++ b/src/store/modules/mapping.js
@@ -570,7 +570,7 @@ const actions = {
         if (deleted) {
           let mapping = mappings[index]
           // Check if current original was amongst the removed mappings
-          if (mapping.uri == state.original.mapping.uri && jskos.compare(_.get(mapping, "_provider.registry"), state.original)) {
+          if (mapping.uri == state.original.uri && jskos.compare(_.get(mapping, "_provider.registry"), state.original.registry)) {
             // Set original to null
             commit({ type: "set" })
           }

--- a/src/store/modules/mapping.js
+++ b/src/store/modules/mapping.js
@@ -123,7 +123,6 @@ const getters = {
       return false
     }
     if (!state.original.uri) {
-      console.log("no original uri")
       return true
     }
     // If original registry is not the currently chosen registry, return true
@@ -167,7 +166,6 @@ const getters = {
     }) && !isCreatorEqual(state.mapping.creator, original.creator)) {
       return true
     }
-    console.log("not equal (or same?)")
     return !jskos.compareMappings(original, state.mapping)
   },
 


### PR DESCRIPTION
- Integrate changes from new `/status` endpoint. (#451)
- Use mapping URI to keep track of which mapping is currently being edited. (#446)