### PR TITLE
Add generated CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,18 @@
+cff-version: 1.2.0
+message: "If you use cocoda, please cite it using the metadata from this file."
+type: software
+title: "Cocoda Mapping Tool"
+authors:
+  - family-names: "Voß"
+    given-names: "Jakob"
+    email: "jakob.voss@gbv.de"
+  - family-names: "Marraffa"
+    given-names: "Rodolfo"
+    email: "rodolfo.marraffa@gbv.de"
+  - family-names: "Peters"
+    given-names: "Stefan"
+    email: "stefan.peters@gbv.de"
+repository-code: "https://github.com/gbv/cocoda"
+license: MIT
+version: "1.12.3"
+

--- a/bin/citation-cff.js
+++ b/bin/citation-cff.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import fs from "fs"
+
+const pkg = JSON.parse(fs.readFileSync(new URL("../package.json", import.meta.url), "utf-8"))
+
+const quote = value => `"${String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
+
+function parsePerson(value) {
+  const match = String(value).match(/^\s*(.*?)\s*(?:<([^>]+)>)?\s*$/)
+  const name = match?.[1] || String(value)
+  const email = match?.[2]
+  const parts = name.trim().split(/\s+/)
+  const familyNames = parts.length > 1 ? parts.pop() : parts[0]
+  const givenNames = parts.length > 0 && parts.join(" ") !== familyNames ? parts.join(" ") : undefined
+  return { familyNames, givenNames, email }
+}
+
+function repositoryCode() {
+  const repository = typeof pkg.repository === "string" ? pkg.repository : pkg.repository?.url
+  return repository?.replace(/^git\+/, "").replace(/\.git$/, "")
+}
+
+const people = [pkg.author, ...(pkg.contributors || [])].filter(Boolean).map(parsePerson)
+const lines = [
+  "cff-version: 1.2.0",
+  `message: ${quote(`If you use ${pkg.name}, please cite it using the metadata from this file.`)}`,
+  "type: software",
+  `title: ${quote(pkg.description || pkg.name)}`,
+  "authors:",
+]
+
+for (const person of people) {
+  lines.push(`  - family-names: ${quote(person.familyNames)}`)
+  if (person.givenNames) lines.push(`    given-names: ${quote(person.givenNames)}`)
+  if (person.email) lines.push(`    email: ${quote(person.email)}`)
+}
+
+const repo = repositoryCode()
+if (repo) lines.push(`repository-code: ${quote(repo)}`)
+if (pkg.license) lines.push(`license: ${pkg.license}`)
+if (pkg.version) lines.push(`version: ${quote(pkg.version)}`)
+
+console.log(`${lines.join("\n")}\n`)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "Stefan Peters <stefan.peters@gbv.de>"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gbv/cocoda.git"
+  },
   "private": true,
   "type": "module",
   "scripts": {
@@ -21,6 +25,7 @@
     "lint-staged": "lint-staged",
     "loc": "cloc $(git ls-files)",
     "build-info": "./build/build-info.js > ./build/build-info.json",
+    "citation": "node ./bin/citation-cff.js > CITATION.cff",
     "manual": "make -BC docs",
     "manual-pdf": "make -BC docs pdfs",
     "release:patch": "./bin/release.sh patch",


### PR DESCRIPTION
Related to #784.

This adds a generated `CITATION.cff` while keeping `package.json` as the source of truth.

What changed:

- added a small `bin/citation-cff.js` generator with no new dependencies;
- added `npm run citation`;
- added repository metadata to `package.json`;
- committed the generated root `CITATION.cff` so GitHub can show "Cite this repository" immediately.

The generated CFF uses the current `package.json` name/description, author, contributors, license, version, and repository URL.

Local checks:

- `npm run citation`;
- `node --check bin/citation-cff.js`;
- generated output matches the committed `CITATION.cff`;
- parsed `CITATION.cff` as YAML;
- `git diff --check`.

I did not run the full project lint because dependencies are not installed in my local checkout. I also could not run `cffconvert --validate` because `cffconvert` is not installed in this environment.
